### PR TITLE
Fix CSP errors in browser console

### DIFF
--- a/assets/js/theme-init.js
+++ b/assets/js/theme-init.js
@@ -1,0 +1,1 @@
+(function(){var t=localStorage.getItem('theme');if(!t){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}document.documentElement.setAttribute('data-theme',t)})();

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,9 +1,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script>
-    (function(){var t=localStorage.getItem('theme');if(!t){t=window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light'}document.documentElement.setAttribute('data-theme',t)})();
-  </script>
+  {{- $themeInit := resources.Get "js/theme-init.js" | minify | fingerprint }}
+  <script src="{{ $themeInit.RelPermalink }}" integrity="{{ $themeInit.Data.Integrity }}"></script>
   <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} · {{ site.Title }}{{ end }}</title>
   {{- with site.Params.description }}
   <meta name="description" content="{{ . }}" />

--- a/static/_headers
+++ b/static/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'sha256-2Ptcn+7v/Z6/R1jptNUtV5JJH5U06JRNHru62MqQrzs=' https://comments.softinio.com/js/embed.min.js https://wisdom.softinio.com/matomo.js https://static.cloudflareinsights.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://wisdom.softinio.com https://*.cloudflareinsights.com https://comments.softinio.com; img-src 'self' https: data:; frame-src https://www.youtube-nocookie.com https://watch.softinio.com https://open.substack.com https://vimeo.com https://comments.softinio.com; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://comments.softinio.com/js/embed.min.js https://wisdom.softinio.com/matomo.js https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://wisdom.softinio.com https://*.cloudflareinsights.com https://comments.softinio.com; img-src 'self' https: data:; frame-src https://www.youtube-nocookie.com https://watch.softinio.com https://open.substack.com https://vimeo.com https://comments.softinio.com; object-src 'none'; base-uri 'self'
 
 # Fingerprinted assets — cache forever (filename changes when content changes)
 /css/*


### PR DESCRIPTION
Fixes two CSP violations visible in the browser console.

## Issue 1: Inline theme script blocked (script-src)

`hugo --minify` minifies HTML including inline script whitespace, so the pre-computed SHA256 hash in `script-src` no longer matched the actual rendered output.

**Fix:** Extract the theme detection script to `assets/js/theme-init.js` and load it via Hugo Pipes (`minify | fingerprint` + SRI integrity attribute). It's served from `'self'` so no hash is needed in the CSP. Loaded synchronously (no `defer`) to prevent flash of unstyled content (FOUC). Remove the stale `sha256-...` from `script-src`.

## Issue 2: Isso inline styles blocked (style-src)

Isso's `embed.min.js` injects inline styles at runtime even when `data-isso-css="false"` is set.

**Fix:** Add `'unsafe-inline'` to `style-src`. Inline styles cannot execute JavaScript so the security impact is minimal.

## Not fixed: Cloudflare Insights 502

`https://static.cloudflareinsights.com/beacon.min.js` returning 502 is an external Cloudflare service issue, not caused by our code.