### PR TITLE
Replace DeterminateSystems Nix actions with cachix + nix-community/cache-nix-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Cache Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-primary-key: never
 
       - name: Build site (pull request)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What

Replaces the two DeterminateSystems GitHub Actions with account-free alternatives:

| Before | After |
|---|---|
| `DeterminateSystems/nix-installer-action@main` | `cachix/install-nix-action@v31` |
| `DeterminateSystems/magic-nix-cache-action@v8` | `nix-community/cache-nix-action@v6` |

## Why

- No external account or additional secrets required — cache is backed by GitHub Actions cache (`GITHUB_TOKEN` is always available)
- `nix-community/cache-nix-action` caches the Nix store keyed on `*.nix` files and `flake.lock`, restoring on cache hits and purging stale entries automatically
- 10 GB GitHub Actions cache quota is more than sufficient for this site's Nix closure