### PR TITLE
Fix Pagefind WASM CSP violation on search page

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://comments.softinio.com/js/embed.min.js https://wisdom.softinio.com/matomo.js https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://wisdom.softinio.com https://*.cloudflareinsights.com https://comments.softinio.com; img-src 'self' https: data:; frame-src https://www.youtube-nocookie.com https://watch.softinio.com https://open.substack.com https://vimeo.com https://comments.softinio.com; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://comments.softinio.com/js/embed.min.js https://wisdom.softinio.com/matomo.js https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://wisdom.softinio.com https://*.cloudflareinsights.com https://comments.softinio.com; img-src 'self' https: data:; frame-src https://www.youtube-nocookie.com https://watch.softinio.com https://open.substack.com https://vimeo.com https://comments.softinio.com; object-src 'none'; base-uri 'self'
 
 # Fingerprinted assets — cache forever (filename changes when content changes)
 /css/*


### PR DESCRIPTION
## Problem

The `/search/` page throws a CSP error in the browser console:

> *WebAssembly.instantiate(): Compiling or instantiating a WebAssembly module violates the following Content Security Policy directive: 'script-src 'self' ...'*

Pagefind's search worker uses WebAssembly, which requires explicit permission in the CSP.

## Fix

Add `'wasm-unsafe-eval'` to the `script-src` directive in `static/_headers`.

This is the targeted, minimal-privilege fix — `'wasm-unsafe-eval'` permits only WebAssembly compilation/instantiation, unlike `'unsafe-eval'` which would also allow arbitrary JS `eval()`.