### PR TITLE
perf: fix forced reflow in copy-code.js

### DIFF
--- a/assets/js/copy-code.js
+++ b/assets/js/copy-code.js
@@ -8,12 +8,6 @@
       // skip if already has a button
       if (block.querySelector('.copy-code-btn')) return;
 
-      // wrap in a relative container
-      var wrapper = document.createElement('div');
-      wrapper.className = 'code-block-wrapper';
-      block.parentNode.insertBefore(wrapper, block);
-      wrapper.appendChild(block);
-
       var btn = document.createElement('button');
       btn.className = 'copy-code-btn';
       btn.setAttribute('aria-label', 'Copy code');
@@ -46,6 +40,15 @@
         });
       });
 
+      // Build the wrapper before touching the live DOM.
+      // replaceWith() atomically swaps block → wrapper (one write).
+      // block is now detached, so appendChild() needs no layout read.
+      // This avoids the forced reflow caused by the old two-step
+      // insertBefore(wrapper) → appendChild(block) pattern.
+      var wrapper = document.createElement('div');
+      wrapper.className = 'code-block-wrapper';
+      block.replaceWith(wrapper);
+      wrapper.appendChild(block);
       wrapper.appendChild(btn);
     });
   }


### PR DESCRIPTION
Addresses the two issues from the latest PageSpeed run.

## Forced reflow — fixed in code

`copy-code.js` was using a two-step DOM insertion that forced a synchronous layout:

```js
// OLD — causes forced reflow
block.parentNode.insertBefore(wrapper, block); // write → invalidates layout
wrapper.appendChild(block);                    // browser must read block's position first
```

Fixed by using `replaceWith()`, which atomically swaps `block` out of the live tree in a single write. `block` is then detached, so the subsequent `appendChild` needs no layout read:

```js
// NEW — no forced reflow
block.replaceWith(wrapper);   // single atomic write
wrapper.appendChild(block);   // block is detached — no layout read needed
wrapper.appendChild(btn);
```

## Cache lifetimes (Cloudflare beacon) — requires dashboard action

PageSpeed flagged `/beacon.min.js` from `static.cloudflareinsights.com` with a 1-day cache TTL. This script is **auto-injected by Cloudflare Pages** and cannot be changed from the codebase — its cache headers are controlled by Cloudflare's CDN, not our `_headers` file.

**To fix:** disable **Cloudflare Web Analytics** in the Cloudflare dashboard for this site. The site already uses Matomo for analytics, so the beacon is redundant and its removal also eliminates the 23 KiB of third-party JavaScript it loads.

https://claude.ai/code/session_01CgqJ1srERQZgdtLUmNrVAN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgqJ1srERQZgdtLUmNrVAN)_